### PR TITLE
Fix most popular count

### DIFF
--- a/src/baseline/co_occurrence.jl
+++ b/src/baseline/co_occurrence.jl
@@ -26,8 +26,7 @@ function build!(recommender::CoOccurrence)
     n_item = size(recommender.data.R, 2)
 
     v_ref = recommender.data.R[:, recommender.i_ref]
-    almost_zero = 1e-256 # to check if value is zero or undef
-    c = count(>(almost_zero), v_ref)
+    c = count(!isalmostzero, v_ref)
 
     for i in 1:n_item
         v = recommender.data.R[:, i]

--- a/src/baseline/co_occurrence.jl
+++ b/src/baseline/co_occurrence.jl
@@ -26,11 +26,12 @@ function build!(recommender::CoOccurrence)
     n_item = size(recommender.data.R, 2)
 
     v_ref = recommender.data.R[:, recommender.i_ref]
-    c = count(!iszero, v_ref)
+    almost_zero = 1e-256 # to check if value is zero or undef
+    c = count(>(almost_zero), v_ref)
 
     for i in 1:n_item
         v = recommender.data.R[:, i]
-        cc = length(v_ref[(v_ref .> 0) .& (v .> 0)])
+        cc = length(v_ref[(v_ref .> almost_zero) .& (v .> almost_zero)])
         recommender.scores[i] = cc / c * 100.0
     end
 end

--- a/src/baseline/most_popular.jl
+++ b/src/baseline/most_popular.jl
@@ -21,9 +21,8 @@ isbuilt(recommender::MostPopular) = isfilled(recommender.scores)
 function build!(recommender::MostPopular)
     n_item = size(recommender.data.R, 2)
 
-    almost_zero = 1e-256 # to check if value is zero or undef
     for i in 1:n_item
-        recommender.scores[i] = count(>(almost_zero), recommender.data.R[:, i])
+        recommender.scores[i] = count(!isalmostzero, recommender.data.R[:, i])
     end
 end
 

--- a/src/baseline/most_popular.jl
+++ b/src/baseline/most_popular.jl
@@ -21,8 +21,9 @@ isbuilt(recommender::MostPopular) = isfilled(recommender.scores)
 function build!(recommender::MostPopular)
     n_item = size(recommender.data.R, 2)
 
+    almost_zero = 1e-256 # to check if value is zero or undef
     for i in 1:n_item
-        recommender.scores[i] = count(!iszero, recommender.data.R[:, i])
+        recommender.scores[i] = count(>(almost_zero), recommender.data.R[:, i])
     end
 end
 

--- a/src/baseline/threshold_percentage.jl
+++ b/src/baseline/threshold_percentage.jl
@@ -25,9 +25,10 @@ isbuilt(recommender::ThresholdPercentage) = isfilled(recommender.scores)
 function build!(recommender::ThresholdPercentage)
     n_item = size(recommender.data.R, 2)
 
+    almost_zero = 1e-256 # to check if value is zero or undef
     for i in 1:n_item
         v = recommender.data.R[:, i]
-        recommender.scores[i] = length(v[v .>= recommender.th]) / count(!iszero, v) * 100.0
+        recommender.scores[i] = length(v[v .>= recommender.th]) / count(>(almost_zero), v) * 100.0
     end
 end
 

--- a/src/baseline/threshold_percentage.jl
+++ b/src/baseline/threshold_percentage.jl
@@ -25,10 +25,9 @@ isbuilt(recommender::ThresholdPercentage) = isfilled(recommender.scores)
 function build!(recommender::ThresholdPercentage)
     n_item = size(recommender.data.R, 2)
 
-    almost_zero = 1e-256 # to check if value is zero or undef
     for i in 1:n_item
         v = recommender.data.R[:, i]
-        recommender.scores[i] = length(v[v .>= recommender.th]) / count(>(almost_zero), v) * 100.0
+        recommender.scores[i] = length(v[v .>= recommender.th]) / count(!isalmostzero, v) * 100.0
     end
 end
 

--- a/src/data_accessor.jl
+++ b/src/data_accessor.jl
@@ -19,7 +19,9 @@ struct DataAccessor
         for user in 1:n_user
             for item in 1:n_item
                 r = R[user, item]
-                if !isnan(r) && r != 0
+                if isnan(r)
+                    R[user, item] = 0
+                elseif r != 0
                     append!(events, [Event(user, item, r)])
                 end
             end

--- a/src/evaluation/cross_validation.jl
+++ b/src/evaluation/cross_validation.jl
@@ -35,7 +35,9 @@ function cross_validation(n_fold::Int, metric::Type{<:RankingMetric}, k::Int, re
         recommender = recommender_type(train_data, recommender_args...)
         build!(recommender)
 
-        accum += evaluate(recommender, truth_data, metric(), k)
+        accuracy = evaluate(recommender, truth_data, metric(), k)
+        if isnan(accuracy); continue; end
+        accum += accuracy
     end
 
     accum / n_fold
@@ -75,7 +77,9 @@ function cross_validation(n_fold::Int, metric::Type{<:AccuracyMetric}, recommend
         recommender = recommender_type(train_data, recommender_args...)
         build!(recommender)
 
-        accum += evaluate(recommender, truth_data, metric())
+        accuracy = evaluate(recommender, truth_data, metric())
+        if isnan(accuracy); continue; end
+        accum += accuracy
     end
 
     accum / n_fold

--- a/src/model/item_knn.jl
+++ b/src/model/item_knn.jl
@@ -46,10 +46,11 @@ function build!(recommender::ItemKNN; adjusted_cosine::Bool=false)
     R = copy(recommender.data.R)
     n_row, n_col = size(R)
 
+    almost_zero = 1e-256 # to check if value is zero or undef
     if adjusted_cosine
         # subtract mean
         for ri in 1:n_row
-            indices = broadcast(!isnan, R[ri, :])
+            indices = broadcast(>(almost_zero), R[ri, :])
             vmean = mean(R[ri, indices])
             R[ri, indices] .-= vmean
         end
@@ -85,9 +86,10 @@ function predict(recommender::ItemKNN, u::Int, i::Int)
     pairs = collect(zip(1:size(recommender.data.R)[2], max.(recommender.sim[i, :], 0)))
     ordered_pairs = sort(pairs, by=tuple->last(tuple), rev=true)[1:recommender.k]
 
+    almost_zero = 1e-256 # to check if value is zero or undef
     for (j, s) in ordered_pairs
         r = recommender.data.R[u, j]
-        if isnan(r); continue; end
+        if r <= almost_zero; continue; end
 
         numer += s * r
         denom += s

--- a/src/model/item_knn.jl
+++ b/src/model/item_knn.jl
@@ -46,11 +46,10 @@ function build!(recommender::ItemKNN; adjusted_cosine::Bool=false)
     R = copy(recommender.data.R)
     n_row, n_col = size(R)
 
-    almost_zero = 1e-256 # to check if value is zero or undef
     if adjusted_cosine
         # subtract mean
         for ri in 1:n_row
-            indices = broadcast(>(almost_zero), R[ri, :])
+            indices = broadcast(!isalmostzero, R[ri, :])
             vmean = mean(R[ri, indices])
             R[ri, indices] .-= vmean
         end
@@ -86,10 +85,9 @@ function predict(recommender::ItemKNN, u::Int, i::Int)
     pairs = collect(zip(1:size(recommender.data.R)[2], max.(recommender.sim[i, :], 0)))
     ordered_pairs = sort(pairs, by=tuple->last(tuple), rev=true)[1:recommender.k]
 
-    almost_zero = 1e-256 # to check if value is zero or undef
     for (j, s) in ordered_pairs
         r = recommender.data.R[u, j]
-        if r <= almost_zero; continue; end
+        if isalmostzero(r); continue; end
 
         numer += s * r
         denom += s

--- a/src/model/user_knn.jl
+++ b/src/model/user_knn.jl
@@ -98,8 +98,9 @@ function predict(recommender::UserKNN, u::Int, i::Int)
 
     pred = (denom == 0) ? 0 : numer / denom
     if recommender.normalize
-        ii = broadcast(!isnan, recommender.data.R[u, :])
-        pred += mean(recommender.data.R[u, ii])
+        ii = broadcast(>(almost_zero), recommender.data.R[u, :])
+        m = mean(recommender.data.R[u, ii])
+        pred += isnan(m) ? 0 : m
     end
     pred
 end

--- a/src/model/user_knn.jl
+++ b/src/model/user_knn.jl
@@ -50,10 +50,11 @@ function build!(recommender::UserKNN)
 
     n_row = size(R, 1)
 
+    almost_zero = 1e-256 # to check if value is zero or undef
     for ri in 1:n_row
         for rj in ri:n_row
             # pairwise correlation (i.e., ignore NaNs)
-            ij = broadcast(!isnan, R[ri, :]) .& broadcast(!isnan, R[rj, :])
+            ij = broadcast(>(almost_zero), R[ri, :]) .& broadcast(>(almost_zero), R[rj, :])
 
             vi = R[ri, :] .- mean(R[ri, ij])
             vj = R[rj, :] .- mean(R[rj, ij])
@@ -78,15 +79,16 @@ function predict(recommender::UserKNN, u::Int, i::Int)
     # closest neighbor is always target user him/herself, so omit him/her
     ordered_pairs = sort(pairs, by=tuple->last(tuple), rev=true)[2:(recommender.k + 1)]
 
+    almost_zero = 1e-256 # to check if value is zero or undef
     for (u_near, w) in ordered_pairs
         v_near = recommender.data.R[u_near, :]
 
         r = v_near[i]
-        if isnan(r); continue; end
+        if r <= almost_zero; continue; end
 
         r_ = 0
         if recommender.normalize
-            jj = broadcast(!isnan, v_near)
+            jj = broadcast(>(almost_zero), v_near)
             r_ = mean(v_near[jj])
         end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-export Event, matrix, vector, isfilled
+export Event, matrix, vector, isfilled, almost_zero, isalmostzero
 
 mutable struct Event
     user::Int
@@ -16,4 +16,10 @@ end
 
 function isfilled(a::AbstractArray)
     nothing ∉ Set(a)
+end
+
+almost_zero = 1e-256 # including `undef`
+
+function isalmostzero(x::Number)
+    x <= almost_zero
 end

--- a/test/baseline/test_most_popular.jl
+++ b/test/baseline/test_most_popular.jl
@@ -6,6 +6,15 @@ function test_most_popular()
     build!(recommender)
     @test ranking(recommender, 1, 1) == 2.0
     @test ranking(recommender, 1, 3) == 1.0
+
+    n_user, n_item = 5, 10
+    events = [Event(1, 2, 1), Event(3, 2, 1), Event(2, 6, 4)]
+    data = DataAccessor(events, n_user, n_item)
+    recommender = MostPopular(data)
+    build!(recommender)
+    @test ranking(recommender, 1, 1) == 0.0
+    @test ranking(recommender, 1, 2) == 2.0
+    @test ranking(recommender, 1, 6) == 1.0
 end
 
 test_most_popular()


### PR DESCRIPTION
Fix #16 

After 6031452283a5b466c7fff1246c138cfbdf73d935, missing values are filled out by `undef`. 

`MostPopular` must not count any zeros and `undef`s, which equal very small numbers.