### PR TITLE
Fix ML100k data to be loadeed even with path=nothing

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -76,7 +76,11 @@ function load_movielens_100k(path::Union{String, Nothing}=nothing)
     R = matrix(n_user, n_item)
 
     if path == nothing || !isdir(path)
-        zip_path = joinpath(dirname(path), "ml-100k.zip")
+        zip_path = if path == nothing
+            joinpath(get_data_home(), "ml-100k.zip")
+        else
+            joinpath(dirname(path), "ml-100k.zip")
+        end
         if !isfile(zip_path)
             zip_path = download_file("https://files.grouplens.org/datasets/movielens/ml-100k.zip", zip_path)
         end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -24,13 +24,15 @@ Download a dataset from the URL to the path. Create folders if needed. `path=not
 """
 function download_file(url::String, path::Union{String, Nothing}=nothing)
     if path == nothing
-        path = tempname()
+        path = joinpath(tempname(), basename(url))
     end
     if isfile(path)
-        error("file already exists: $path")
+        @warn "file already exists, so skip downloading: $path"
+        path
+    else
+        data_home = get_data_home(dirname(path))  # ensure the directory exists
+        Downloads.download(url, joinpath(data_home, basename(path)))
     end
-    data_home = get_data_home(dirname(path))  # ensure the directory exists
-    Downloads.download(url, joinpath(data_home, basename(path)))
 end
 
 
@@ -76,14 +78,11 @@ function load_movielens_100k(path::Union{String, Nothing}=nothing)
     R = matrix(n_user, n_item)
 
     if path == nothing || !isdir(path)
-        zip_path = if path == nothing
-            joinpath(get_data_home(), "ml-100k.zip")
-        else
-            joinpath(dirname(path), "ml-100k.zip")
+        zip_path = path
+        if zip_path != nothing
+            zip_path = joinpath(dirname(zip_path), "ml-100k.zip")
         end
-        if !isfile(zip_path)
-            zip_path = download_file("https://files.grouplens.org/datasets/movielens/ml-100k.zip", zip_path)
-        end
+        zip_path = download_file("https://files.grouplens.org/datasets/movielens/ml-100k.zip", zip_path)
         path = joinpath(unzip(zip_path, path), "ml-100k/")
     end
 

--- a/test/test_datasets.jl
+++ b/test/test_datasets.jl
@@ -10,7 +10,7 @@ function test_download_file()
     iris_url = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data"
     path = download_file(iris_url)
     @test isfile(path)
-    @test_throws ErrorException download_file(iris_url, path)
+    @test path == download_file(iris_url, path)
 end
 
 function test_unzip()

--- a/test/test_datasets.jl
+++ b/test/test_datasets.jl
@@ -32,10 +32,19 @@ function test_unzip()
 end
 
 function test_load_movielens_100k()
+    dir = mktempdir()
+    println("-- Testing to download and read the MovieLens 100k data without specifying a path (JULIA_RECOMMENDATION_DATA=$dir)")
+    ENV["JULIA_RECOMMENDATION_DATA"] = dir
+    data = load_movielens_100k()
+    validate_movielens_100k(data)
+
     path = tempname()
     println("-- Testing to download and read the MovieLens 100k data file: $path")
     data = load_movielens_100k(path)
+    validate_movielens_100k(data)
+end
 
+function validate_movielens_100k(data::DataAccessor)
     @test data.R[196, 242] == 3.0
     @test data.R[186, 302] == 3.0
     @test data.R[22, 377] == 1.0


### PR DESCRIPTION
There is a bug - `dirname(nothing)` should fail.