### PR TITLE
Add `load_libsvm_file` function to parse libsvm data

### DIFF
--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -38,3 +38,12 @@ SyntheticFeature
 SyntheticRule
 generate
 ```
+
+## Helper functions
+
+```@docs
+get_data_home
+download_file
+unzip
+load_libsvm_file
+```

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -65,6 +65,35 @@ function unzip(path::String, exdir::Union{String, Nothing}=nothing)
 end
 
 
+"""
+    load_libsvm_file(path::String; zero_based::Bool=false, n_features::Union{Integer, Nothing}=nothing) -> X, y
+
+Read a sparse matrix dataset represented by [libsvm format](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/).
+Each row of X and y corresponds to a pair of sample that is already transformed to a vector; since there is no concept of
+user/item ID in the data, users may need to manually translate the resulting matrix/vector to `DataAccessor` as:
+
+```julia
+n_user, n_item = ...
+
+X, y = load_libsvm_file("/path/to/data.libsvm")
+
+events = Event[]
+for i in 1:length(y)
+    user, item = ... # find user/item ID per row based on your definition
+    push!(events, Event(user, item, y[i]))
+
+data = DataAccessor(events, n_user, n_item)
+
+# declare which columns in X represent user and item features, respectively
+user_feature_indices = [...]
+item_feature_indices = [...]
+
+for i in 1:size(X, 1)
+    user, item = ... # find user/item ID per row based on your definition
+    set_user_attributes(data, user, X[i, user_feature_indices])
+    set_item_attributes(data, item, X[i, item_feature_indices])
+```
+"""
 function load_libsvm_file(path::String; zero_based::Bool=false, n_features::Union{Integer, Nothing}=nothing)
     y = Float64[]
     X = []

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -1,4 +1,4 @@
-export get_data_home, download_file, unzip, load_movielens_100k, load_movielens_latest, load_amazon_review, load_lastfm
+export get_data_home, download_file, unzip, load_libsvm_file, load_movielens_100k, load_movielens_latest, load_amazon_review, load_lastfm
 
 """
     get_data_home([data_home=nothing]) -> String
@@ -62,6 +62,37 @@ function unzip(path::String, exdir::Union{String, Nothing}=nothing)
     end
     close(zip_reader)
     exdir
+end
+
+
+function load_libsvm_file(path::String, n_features::Integer; zero_based::Bool=false)
+    y = Float64[]
+    X = []
+    open(path, "r") do io
+        for line in eachline(io)
+            l = split(line, " ")
+
+            y_value = parse(Float64, l[1])
+            push!(y, y_value)
+
+            row = zeros(1, n_features)
+            pairs = map(elm -> split(elm, ":"), l[2:end])
+            for (index, value) in pairs
+                idx, val = parse(Int, string(index)), parse(Float64, string(value))
+                if zero_based
+                    idx += 1
+                end
+                row[idx] = val
+            end
+
+            if isempty(X)
+                X = row
+            else
+                X = [X; row]
+            end
+        end
+    end
+    X, y
 end
 
 

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -97,15 +97,20 @@ function load_libsvm_file(path::String; zero_based::Bool=false, n_features::Unio
 
             if isempty(X)
                 X = row
-            elseif infer_n_features
-                n_features = max(n_features, length(row))
-                n_rows, n_cols = size(X)
-                # adjust the size of an entire matrix based on the largest # of features so far
-                X = [X zeros(n_rows, max(0, n_features - n_cols));
-                     row zeros(1, max(0, n_cols - n_features))]
-            else
-                X = [X; row]
+                continue
             end
+
+            if infer_n_features
+                n_features = max(n_features, length(row))
+                # adjust the size of an entire matrix based on the largest # of features so far
+                n_rows, n_cols = size(X)
+                if n_features > n_cols
+                    X = [X zeros(n_rows, n_features - n_cols)]
+                else
+                    row = [row zeros(1, n_cols - n_features)]
+                end
+            end
+            X = [X; row]
         end
     end
 

--- a/test/test_datasets.jl
+++ b/test/test_datasets.jl
@@ -37,7 +37,7 @@ function test_load_libsvm_file()
     f = tempname()
     write(f, "1.0 0:1.0 2:-1.0\n-1.0 1:10 3:-10\n")
 
-    X, y = load_libsvm_file(f, 4, zero_based=true)
+    X, y = load_libsvm_file(f, zero_based=true)
 
     @test size(X) == (2, 4)
     @test X == [1.0 0.0 -1.0 0.0; 0.0 10.0 0.0 -10.0]

--- a/test/test_datasets.jl
+++ b/test/test_datasets.jl
@@ -31,6 +31,20 @@ function test_unzip()
     @test isfile(joinpath(exdir, "hello.txt"))
 end
 
+function test_load_libsvm_file()
+    println("-- Testing libsvm file loader")
+
+    f = tempname()
+    write(f, "1.0 0:1.0 2:-1.0\n-1.0 1:10 3:-10\n")
+
+    X, y = load_libsvm_file(f, 4, zero_based=true)
+
+    @test size(X) == (2, 4)
+    @test X == [1.0 0.0 -1.0 0.0; 0.0 10.0 0.0 -10.0]
+    @test length(y) == 2
+    @test y == [1.0, -1.0]
+end
+
 function test_load_movielens_100k()
     dir = mktempdir()
     println("-- Testing to download and read the MovieLens 100k data without specifying a path (JULIA_RECOMMENDATION_DATA=$dir)")
@@ -101,6 +115,7 @@ end
 
 test_get_data_home()
 test_unzip()
+test_load_libsvm_file()
 
 if "download" in ARGS
     test_download_file()


### PR DESCRIPTION
Resolve #32 

- [x] Make `n_features` optional to infer feature size
- [ ] ~Return `DataAccessor` where possible.~
  - -> Treated this as a specific use case in docstring.