### PR TITLE
Optimize `recommend()` with bulk prediction

### DIFF
--- a/src/base_recommender.jl
+++ b/src/base_recommender.jl
@@ -29,7 +29,10 @@ function fit!(recommender::Recommender; kwargs...)
 end
 
 function recommend(recommender::Recommender, user::Integer, topk::Integer, candidates::AbstractVector{T}) where {T<:Integer}
-    pairs = filter(p -> !isnan(last(p)), [item => predict(recommender, user, item) for item in candidates])
+    pairs = filter(
+        p -> !isnan(last(p)),
+        candidates .=> predict(recommender, user, candidates)
+    )
     partialsort(pairs, 1:min(length(pairs), topk), by=last, rev=true)
 end
 
@@ -37,10 +40,14 @@ function predict(recommender::Recommender, user::Integer, item::Integer)
     error("predict is not implemented for recommender type $(typeof(recommender))")
 end
 
+function predict(recommender::Recommender, user::Integer, candidates::AbstractVector{T}) where {T<:Integer}
+    predict(recommender, map(item -> CartesianIndex(user, item), candidates))
+end
+
 function predict(recommender::Recommender, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
     n_elements = length(indices)
     pred = zeros(n_elements)
-    Threads.@threads for j in 1:n_elements
+    for j in 1:n_elements
         idx = indices[j]
         pred[j] = predict(recommender, idx[1], idx[2])
     end

--- a/src/base_recommender.jl
+++ b/src/base_recommender.jl
@@ -36,3 +36,13 @@ end
 function predict(recommender::Recommender, user::Integer, item::Integer)
     error("predict is not implemented for recommender type $(typeof(recommender))")
 end
+
+function predict(recommender::Recommender, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
+    n_elements = length(indices)
+    pred = zeros(n_elements)
+    Threads.@threads for j in 1:n_elements
+        idx = indices[j]
+        pred[j] = predict(recommender, idx[1], idx[2])
+    end
+    pred
+end

--- a/src/baseline/co_occurrence.jl
+++ b/src/baseline/co_occurrence.jl
@@ -39,3 +39,9 @@ function predict(recommender::CoOccurrence, user::Integer, item::Integer)
     validate(recommender)
     recommender.scores[item]
 end
+
+function predict(recommender::CoOccurrence, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
+    validate(recommender)
+    items = map(idx -> idx[2], indices)
+    recommender.scores[items]
+end

--- a/src/baseline/item_mean.jl
+++ b/src/baseline/item_mean.jl
@@ -25,3 +25,9 @@ function predict(recommender::ItemMean, user::Integer, item::Integer)
     validate(recommender)
     recommender.scores[item]
 end
+
+function predict(recommender::ItemMean, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
+    validate(recommender)
+    items = map(idx -> idx[2], indices)
+    recommender.scores[items]
+end

--- a/src/baseline/most_popular.jl
+++ b/src/baseline/most_popular.jl
@@ -26,3 +26,9 @@ function predict(recommender::MostPopular, user::Integer, item::Integer)
     validate(recommender)
     recommender.scores[item]
 end
+
+function predict(recommender::MostPopular, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
+    validate(recommender)
+    items = map(idx -> idx[2], indices)
+    recommender.scores[items]
+end

--- a/src/baseline/threshold_percentage.jl
+++ b/src/baseline/threshold_percentage.jl
@@ -32,3 +32,9 @@ function predict(recommender::ThresholdPercentage, user::Integer, item::Integer)
     validate(recommender)
     recommender.scores[item]
 end
+
+function predict(recommender::ThresholdPercentage, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
+    validate(recommender)
+    items = map(idx -> idx[2], indices)
+    recommender.scores[items]
+end

--- a/src/baseline/user_mean.jl
+++ b/src/baseline/user_mean.jl
@@ -27,3 +27,9 @@ function predict(recommender::UserMean, user::Integer, item::Integer)
     validate(recommender)
     recommender.scores[user]
 end
+
+function predict(recommender::UserMean, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
+    validate(recommender)
+    users = map(idx -> idx[1], indices)
+    recommender.scores[users]
+end

--- a/src/evaluation/evaluate.jl
+++ b/src/evaluation/evaluate.jl
@@ -10,10 +10,11 @@ function evaluate(recommender::Recommender, truth_data::DataAccessor,
     validate(recommender, truth_data)
 
     nonzero_indices = findall(!iszero, truth_data.R)
-
-    truth = zeros(length(nonzero_indices))
-    pred = zeros(length(nonzero_indices))
-    for (j, idx) in enumerate(nonzero_indices)
+    n_elements = length(nonzero_indices)
+    truth = zeros(n_elements)
+    pred = zeros(n_elements)
+    Threads.@threads for j in 1:n_elements
+        idx = nonzero_indices[j]
         truth[j] = truth_data.R[idx]
         pred[j] = predict(recommender, idx[1], idx[2])
     end

--- a/src/evaluation/evaluate.jl
+++ b/src/evaluation/evaluate.jl
@@ -10,15 +10,8 @@ function evaluate(recommender::Recommender, truth_data::DataAccessor,
     validate(recommender, truth_data)
 
     nonzero_indices = findall(!iszero, truth_data.R)
-    n_elements = length(nonzero_indices)
-    truth = zeros(n_elements)
-    pred = zeros(n_elements)
-    Threads.@threads for j in 1:n_elements
-        idx = nonzero_indices[j]
-        truth[j] = truth_data.R[idx]
-        pred[j] = predict(recommender, idx[1], idx[2])
-    end
-
+    truth = truth_data.R[nonzero_indices]
+    pred = predict(recommender, nonzero_indices)
     [measure(metric, truth, pred) for metric in metrics]
 end
 

--- a/src/evaluation/evaluate.jl
+++ b/src/evaluation/evaluate.jl
@@ -16,8 +16,8 @@ function evaluate(recommender::Recommender, truth_data::DataAccessor,
 end
 
 function evaluate(recommender::Recommender, truth_data::DataAccessor,
-                  metric::Metric, topk::Integer)
-    evaluate(recommender, truth_data, [metric], topk)[1]
+                  metric::Metric, topk::Integer; allow_repeat=false)
+    evaluate(recommender, truth_data, [metric], topk, allow_repeat=allow_repeat)[1]
 end
 
 function check_metrics_type(metrics::AbstractVector{T},

--- a/src/model/bpr_matrix_factorization.jl
+++ b/src/model/bpr_matrix_factorization.jl
@@ -101,3 +101,8 @@ function predict(recommender::BPRMatrixFactorization, user::Integer, item::Integ
     validate(recommender)
     recommender.R[user, item]
 end
+
+function predict(recommender::BPRMatrixFactorization, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
+    validate(recommender)
+    recommender.R[indices]
+end

--- a/src/model/matrix_factorization.jl
+++ b/src/model/matrix_factorization.jl
@@ -96,3 +96,8 @@ function predict(recommender::MatrixFactorization, user::Integer, item::Integer)
     validate(recommender)
     recommender.R[user, item]
 end
+
+function predict(recommender::MatrixFactorization, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
+    validate(recommender)
+    recommender.R[indices]
+end

--- a/src/model/matrix_factorization.jl
+++ b/src/model/matrix_factorization.jl
@@ -21,13 +21,14 @@ struct MatrixFactorization <: Recommender
     n_factors::Integer
     P::AbstractMatrix
     Q::AbstractMatrix
+    R::AbstractMatrix
 
     function MatrixFactorization(data::DataAccessor, n_factors::Integer)
         n_users, n_items = size(data.R)
         P = matrix(n_users, n_factors)
         Q = matrix(n_items, n_factors)
 
-        new(data, n_factors, P, Q)
+        new(data, n_factors, P, Q, matrix(n_users, n_items))
     end
 end
 
@@ -43,7 +44,7 @@ const MF = MatrixFactorization
 
 MF(data::DataAccessor) = MF(data, 20)
 
-isdefined(recommender::MatrixFactorization) = isfilled(recommender.P)
+isdefined(recommender::MatrixFactorization) = isfilled(recommender.R)
 
 function fit!(recommender::MatrixFactorization;
               reg::Float64=1e-3, learning_rate::Float64=1e-3,
@@ -88,9 +89,10 @@ function fit!(recommender::MatrixFactorization;
 
     recommender.P[:] = P[:]
     recommender.Q[:] = Q[:]
+    recommender.R[:] = P * Q'
 end
 
 function predict(recommender::MatrixFactorization, user::Integer, item::Integer)
     validate(recommender)
-    dot(recommender.P[user, :], recommender.Q[item, :])
+    recommender.R[user, item]
 end

--- a/src/model/svd.jl
+++ b/src/model/svd.jl
@@ -43,3 +43,8 @@ function predict(recommender::SVD, user::Integer, item::Integer)
     validate(recommender)
     recommender.R[user, item]
 end
+
+function predict(recommender::SVD, indices::AbstractVector{T}) where {T<:CartesianIndex{2}}
+    validate(recommender)
+    recommender.R[indices]
+end

--- a/test/baseline/test_co_occurrence.jl
+++ b/test/baseline/test_co_occurrence.jl
@@ -4,6 +4,9 @@ function test_co_occurrence(data)
     @test predict(recommender, 1, 1) == 100.0
     @test predict(recommender, 1, 2) == 50.0
     @test predict(recommender, 1, 3) == 0.0
+
+    actual = predict(recommender, [CartesianIndex(1, 1), CartesianIndex(1, 2), CartesianIndex(1, 3)])
+    @test actual == [100.0, 50.0, 0.0]
 end
 
 println("-- Testing CoOccurrence recommender")

--- a/test/baseline/test_threshold_percentage.jl
+++ b/test/baseline/test_threshold_percentage.jl
@@ -3,6 +3,9 @@ function test_threshold_percentage(data)
     fit!(recommender)
     @test predict(recommender, 1, 1) == 50.0
     @test predict(recommender, 1, 2) == 100.0
+
+    actual = predict(recommender, [CartesianIndex(1, 1), CartesianIndex(1, 2)])
+    @test actual == [50.0, 100.0]
 end
 
 println("-- Testing ThresholdPercentage recommender")

--- a/test/evaluation/test_evaluate.jl
+++ b/test/evaluation/test_evaluate.jl
@@ -36,6 +36,18 @@ function test_evaluate_implicit(v)
 
     # must return a meaningful non-zero value as an error, but it shouldn't be too good (>0.8)
     @test 0.0 < evaluate(recommender, truth_data, Recall(), 4) <= 0.8
+
+    n_items = size(m)[2]
+
+    # top-{all items} recommendation leads to the max coverage
+    @test evaluate(recommender, truth_data, Coverage(), n_items, allow_repeat=true) == 1.0
+
+    # top-{all items} recommendation always give max novelty if repetition is allowed
+    # 5 unobserved (zeros) in user#1 truth, 5 in user#2, 3 in user#3; (5+5+3)/3=4.3333
+    @test isapprox(evaluate(recommender, truth_data, Novelty(), n_items, allow_repeat=true), 4.3333, atol=1e-3)
+
+    # top-{all items} recommendation achieves max diversity across the recs
+    @test evaluate(recommender, truth_data, AggregatedDiversity(), n_items, allow_repeat=true) == n_items
 end
 
 println("-- Testing metrics type validation function")

--- a/test/model/test_bpr_matrix_factorization.jl
+++ b/test/model/test_bpr_matrix_factorization.jl
@@ -10,6 +10,7 @@ function run(recommender::Type{T}, v) where {T<:Recommender}
     # top-4 recommended item set should be same as CF/SVD-based recommender
     rec = recommend(recommender, 1, 4, [i for i in 1:8])
     @test Set([item for (item, score) in rec]) == Set([2, 5, 6, 8])
+    @test predict(recommender, 1, 2) > predict(recommender, 1, 5)
 end
 
 function test_bprmf()

--- a/test/model/test_matrix_factorization.jl
+++ b/test/model/test_matrix_factorization.jl
@@ -10,6 +10,7 @@ function run(recommender::Type{T}, v) where {T<:Recommender}
     # top-4 recommended item set should be same as CF/SVD-based recommender
     rec = recommend(recommender, 1, 4, [i for i in 1:8])
     @test Set([item for (item, score) in rec]) == Set([2, 5, 6, 8])
+    @test predict(recommender, 1, 2) > predict(recommender, 1, 5)
 end
 
 function test_mf()

--- a/test/model/test_svd.jl
+++ b/test/model/test_svd.jl
@@ -16,6 +16,7 @@ function test_svd()
     @test first(rec[2]) == 2
     @test first(rec[3]) == 5
     @test first(rec[4]) == 6
+    @test predict(recommender, 1, 2) > predict(recommender, 1, 5)
 end
 
 test_svd()

--- a/test/test_base_recommender.jl
+++ b/test/test_base_recommender.jl
@@ -38,6 +38,9 @@ function test_recommend()
     @test last(pairs[2]) == 1
     @test first(pairs[3]) == 3
     @test last(pairs[3]) == 0
+
+    @test predict(recommender, 1, 3) == 0
+    @test predict(recommender, [CartesianIndex(1, 3), CartesianIndex(2, 2), CartesianIndex(3, 1)]) == [0, 1, 2]
 end
 
 function test_data_size_validation()


### PR DESCRIPTION
In particular, accelerate calculating matrix factorization-based recommendation scores by pre-computing (caching) an approximated user-item matrix.